### PR TITLE
Remove `si` from the list

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -398,7 +398,7 @@ var PRESETS = map[string]QueryPreset{
 		include: []string{"slovakia", "bratislava", "kosice", "presov", "zilina"},
 	},
 	"slovenia": QueryPreset{
-		include: []string{"slovenia", "slovenija", ",+SI", "ljubljana", "maribor", "celje", "kranj", "koper", "velenje", "novo+mesto", "nova+gorica", "krsko", "krško", "murska+sobota", "postojna", "slovenj+gradec"},
+		include: []string{"slovenia", "slovenija", "ljubljana", "maribor", "celje", "kranj", "koper", "velenje", "novo+mesto", "nova+gorica", "krsko", "krško", "murska+sobota", "postojna", "slovenj+gradec"},
 	},
 	"lithuania": QueryPreset{
 		include: []string{"lithuania", "vilnius", "kaunas", "klaipeda", "siauliai", "panevezys", "alytus"},


### PR DESCRIPTION
There is a problem, that a lot of asian cities contain SI in their names, which is also shortly for Slovenia. I think it's best to remove this, as not many people are using it anyways.

Have a look at current list for Slovenia:
![image](https://user-images.githubusercontent.com/52399966/170891573-f93f286a-d2f7-441e-b7f4-157e0c9cf97e.png)

A lot of these people are clearly asian and have been mislabeled.