### PR TITLE
feat: Add dynamic bold & background styling for table rows based on URL hash

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -176,6 +176,18 @@
     </div>
     <script src="{{ '/assets/js/scale.fix.js' }}"></script>
 
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        var hash = window.location.hash;
+        if (hash) {
+          var id = hash.substring(1);
+          var row = document.getElementById(id);
+          if (row) {
+            row.style.fontWeight = 'bold';
+          }
+        }
+      });
+    </script>
 
   <style type="text/css">
   ul.share-buttons{

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -184,6 +184,7 @@
           var row = document.getElementById(id);
           if (row) {
             row.style.fontWeight = 'bold';
+            row.style.backgroundColor = '#f8f8f8';
           }
         }
       });


### PR DESCRIPTION
This PR adds a JavaScript function that extracts the ID from the URL hash (e.g., #buraksakalli), finds the corresponding <tr> element by its id, and applies font-weight: bold to it. The feature ensures that table rows are highlighted when accessed via URL fragments, enhancing user navigation.

## Screenshot
<img width="327" alt="Screenshot 2024-09-23 at 8 09 20 PM" src="https://github.com/user-attachments/assets/b9ac2ae9-bb72-46a1-92b1-b71ced526f00">


![image](https://github.com/user-attachments/assets/8dd09572-767d-4ca5-aaf3-b546758bde56)
