### PR TITLE
add Pune, Gurgaon, and Noida to India query preset

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -91,7 +91,7 @@ var PRESETS = map[string]QueryPreset{
 		include: []string{"china", "中国", "guangzhou", "shanghai", "beijing", "hangzhou"},
 	},
 	"india": QueryPreset{
-		include: []string{"india", "mumbai", "delhi", "bangalore", "hyderabad", "ahmedabad", "chennai", "kolkata", "jaipur"},
+		include: []string{"india", "mumbai", "delhi", "bangalore", "hyderabad", "ahmedabad", "chennai", "kolkata", "jaipur", "pune", "gurgaon", "noida"},
 	},
 	"israel": QueryPreset{
 		include: []string{"israel", "tel+aviv", "jerusalem", "beer+sheva", "beersheva", "netanya", "ramat+gan", "haifa", "herzliya", "rishon"},


### PR DESCRIPTION
# Add Pune, Gurgaon, and Noida to India Query Preset

## Summary

This pull request updates the `india` query preset in `presets.go` by adding three major Indian cities: Pune, Gurgaon, and Noida. These cities are significant IT and business hubs and were previously missing from the list.

These additions will help improve coverage and accuracy for queries related to Indian tech contributors.

## Related Issue

- Closes #59 ("Add more Indian cities")

Thank you for your review!