### PR TITLE
Add more cities to Lebanon query preset.

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -407,7 +407,7 @@ var PRESETS = map[string]QueryPreset{
 		include: []string{"bulgaria", "sofia", "plovdiv", "varna", "burgas", "ruse", "stara+zagora", "pleven"},
 	},
 	"lebanon": QueryPreset{
-		include: []string{"lebanon", "beirut", "sidon", "tyre","tripoli","byblos","bekaa","hermel","jounieh", "zahle", "baalbek", "nabatieh", "jbeil", "batroun", "achrafieh", "hamra","bent jbeil","jezzine"},
+		include: []string{"lebanon", "beirut", "sidon", "tyre", "tripoli", "byblos", "bekaa", "hermel", "jounieh", "zahle", "baalbek", "nabatieh", "jbeil", "batroun", "achrafieh", "hamra","bent jbeil","jezzine"},
 	},
 	"libya": QueryPreset{
 		include: []string{"libya", "tripoli", "benghazi", "misrata", "zliten", "bayda"},

--- a/presets.go
+++ b/presets.go
@@ -407,7 +407,7 @@ var PRESETS = map[string]QueryPreset{
 		include: []string{"bulgaria", "sofia", "plovdiv", "varna", "burgas", "ruse", "stara+zagora", "pleven"},
 	},
 	"lebanon": QueryPreset{
-		include: []string{"lebanon", "beirut", "sidon", "tyre"},
+		include: []string{"lebanon", "beirut", "sidon", "tyre","tripoli","byblos","bekaa","hermel","jounieh", "zahle", "baalbek", "nabatieh", "jbeil", "batroun", "achrafieh", "hamra","bent jbeil","jezzine"},
 	},
 	"libya": QueryPreset{
 		include: []string{"libya", "tripoli", "benghazi", "misrata", "zliten", "bayda"},


### PR DESCRIPTION
This pull request expands the list of included locations for the Lebanon query preset in the `presets.go` file. Now, more cities and regions in Lebanon are covered, improving the comprehensiveness of queries related to Lebanon.

Enhancement to Lebanon preset:

* Expanded the `include` list for the `"lebanon"` entry in `QueryPreset` to add several additional cities and regions, such as "tripoli", "byblos", "bekaa", "hermel", "jounieh", "zahle", "baalbek", "nabatieh", "jbeil", "batroun", "achrafieh", "hamra", "bent jbeil", and "jezzine".