### PR TITLE
Fix: Lebanon ranking preset

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -407,7 +407,7 @@ var PRESETS = map[string]QueryPreset{
 		include: []string{"bulgaria", "sofia", "plovdiv", "varna", "burgas", "ruse", "stara+zagora", "pleven"},
 	},
 	"lebanon": QueryPreset{
-		include: []string{"lebanon", "beirut", "sidon", "tyre", "tripoli", "byblos", "bekaa", "hermel", "jounieh", "zahle", "baalbek", "nabatieh", "jbeil", "batroun", "achrafieh", "hamra","bent jbeil","jezzine"},
+		include: []string{"lebanon", "beirut", "sidon", "tyre", "tripoli", "byblos", "bekaa", "jounieh", "zahle", "baalbek", "nabatieh", "jbeil", "batroun", "achrafieh", "hamra"},
 	},
 	"libya": QueryPreset{
 		include: []string{"libya", "tripoli", "benghazi", "misrata", "zliten", "bayda"},


### PR DESCRIPTION
## This PR fixes the broken Lebanon ranking page ([committers.top/lebanon](https://committers.top/lebanon)) by removing invalid location terms that return no data from the GitHub Search API.

## Changes
- Removed the following invalid location terms from the Lebanon preset:
  - `jezzine`
  - `bent jbeil`
  - `hermel`

These terms return `total_count: 0` from the GitHub API and cause the ranking page to break.

## Related Issue
Closes #77 