### PR TITLE
Update presets for Kosovo

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -599,7 +599,7 @@ var PRESETS = map[string]QueryPreset{
 	},
 	"kosovo": QueryPreset{
 		title:   "Kosovo",
-		include: []string{"kosovo", "kosove", "prishtine"},
+		include: []string{"kosovo", "kosove", "prishtine", "prizren", "peja", "gjakova", "ferizaj", "gjilan", "mitrovica", "podujev", "vushtrri", "suhareke", "rahovec", "lipjan", "skenderaj", "kamenice", "malisheve", "decan", "istog", "kline", "fushe+kosove"},
 	},
 	"madagascar": QueryPreset{
 		title:   "Madagascar",


### PR DESCRIPTION
This PR adds more Kosovo cities to the preset using Albanian names only.

## Changes:
- Added major Kosovo cities: Prizren, Peja, Gjakova, Ferizaj, Gjilan, Mitrovica, Podujev, Vushtrri, Suhareke, Rahovec, Lipjan, Skenderaj, Kamenice, Malisheve, Decan, Istog, Kline, Fushe Kosove
- Updated Kosovo preset to better represent Albanian-speaking population

## Commits:
- **Preset changes:** 55576e4c01 - Updated presets.go with Kosovo cities
- **Generated data:** 8afa4d539 - Daily update workflow successfully generated Kosovo data

## Workflow Results:
The daily_update workflow ran and successfully processed the Kosovo preset, generating updated data (commit 8afa4d539). The workflow partially failed due to GitHub API rate limits during other regions' processing, but Kosovo data was successfully generated.

## Impact:
This improves the accuracy of the Kosovo preset by including more cities and using the correct Albanian spellings, better representing the Albanian-speaking population of Kosovo.
