### PR TITLE
Add Knysna to South Africa

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -189,7 +189,7 @@ var PRESETS = map[string]QueryPreset{
 	},
 	"south africa": QueryPreset{
 		title:   "South Africa",
-		include: []string{"south+africa", "south+africa", "johannesburg", "cape+town", "rsa", "durban", "port+elizabeth", "pretoria", "nelspruit"},
+		include: []string{"south+africa", "south+africa", "johannesburg", "cape+town", "rsa", "durban", "port+elizabeth", "pretoria", "nelspruit", "knysna"},
 	},
 	"myanmar": QueryPreset{
 		title:   "Myanmar",


### PR DESCRIPTION
Adds the town of [Knysna](https://en.wikipedia.org/wiki/Knysna) to the list of South African locations.