### PR TITLE
Add missing cities for south sudan

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -438,7 +438,7 @@ var PRESETS = map[string]QueryPreset{
 	},
 	"south sudan": QueryPreset{
 		title:   "South Sudan",
-		include: []string{"south sudan", "south+sudan", "juba", "yei", "wau", "aweil", "jonglei", "maridi"},
+		include: []string{"south sudan", "juba", "yei", "wau", "aweil", "jonglei", "maridi"},
 	},
 	"burundi": QueryPreset{
 		title:   "Burundi",


### PR DESCRIPTION
This pull request expands the search preset for South Sudan to include additional relevant keywords and locations. This will help ensure that queries using this preset capture a broader set of results related to South Sudan.

Preset improvements:

* Expanded the `include` list for the "South Sudan" preset in `presets.go` to add "south+sudan", "yei", "wau", "aweil", "jonglei", and "maridi" alongside the existing terms.