### PR TITLE
fix/egypt cities

### DIFF
--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          import csv, datetime, glob, os, re, subprocess, sys
+          import csv, datetime, glob, os, random, re, subprocess, sys
 
           MAX_IN_RUN = 3
           STALE_DAYS = 5
@@ -86,6 +86,7 @@ jobs:
           if regenerated:
             subprocess.run('git add *.md _data/locations/*.yml rank_only/*.json && git commit -am "regenerate location pages"', shell=True, check=True)
 
+          random.shuffle(to_process) # in case we're getting failures for a specific preset, this should let others move forward
           for key in to_process[0:MAX_IN_RUN]:
             print("Running: %s" % key)
             preset = flookup[key]


### PR DESCRIPTION
## Summary
This PR significantly improves the coverage for Egyptian developers by expanding the `egypt` preset in [presets.go](cci:7://file:///Users/hatem/Desktop/Entrepreneur/Career/Startups/Open%20Source/committers.top/presets.go:0:0-0:0).

## Issue Number:
https://github.com/ashkulz/committers.top/issues/108

## Changes
1. **Corrected Typos**: Fixed `tanda` → `tanta`
2. **Comprehensive Coverage**: Added all 27 Egyptian Governorates and their capitals
3. **Major Cities & Hubs**: Included industrial/residential areas like:
   - "6th of October", "10th of Ramadan", "New Cairo", "Obour City"
   - "El Gouna", "Ain Shams", "Ain El Sokhna"
4. **Spelling Variations**: Added common English transliterations for better matching:
   - `asyut` / `asiut`
   - `fayoum` / `faiyum`
   - `sharkia` / `sharqia`
   - `al+mansurah` / `mansoura`
5. **Colloquial Terms**: Added `masr`, `om+el+donia`, `heliopolis`, `nasr+city`

## Why This Matters
GitHub's location field is free-text, so developers spell their cities differently. By adding variations, we maximize the chance of correctly identifying Egyptian developers regardless of how they spelled their location.

## Testing
- Verified Go syntax is valid
- Confirmed URL encoding with `+` for spaces follows existing patterns in the codebase