### PR TITLE
Add Kurdistan preset with included cities

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -613,6 +613,10 @@ var PRESETS = map[string]QueryPreset{
 		title:   "Bosnia and Herzegovina",
 		include: []string{"sarajevo", "banja+luka", "tuzla", "zenica", "bijeljina", "mostar", "prijedor", "brcko", "doboj", "cazin"},
 	},
+	"kurdistan": QueryPreset{
+	    title:   "Kurdistan",
+	    include: []string{"kurdistan", "erbil", "hawler", "sulaymaniyah", "slemani", "duhok", "halabja", "kirkuk"},
+	},
 }
 
 func Preset(name string) QueryPreset {

--- a/presets.go
+++ b/presets.go
@@ -579,7 +579,7 @@ var PRESETS = map[string]QueryPreset{
 	},
 	"iraq": QueryPreset{
 		title:   "Iraq",
-		include: []string{"baghdad", "mosul", "basra", "kirkuk", "erbil", "najaf", "karbala", "sulaymaniya", "al-nasiriya", "al-amarah"},
+		include: []string{"baghdad", "mosul", "basra", "najaf", "karbala", "al-nasiriya", "al-amarah"},
 	},
 	"qatar": QueryPreset{
 		title:   "Qatar",


### PR DESCRIPTION
Kurdistan is a semi-autonomous region with a growing tech community and many developers who want representation on committers.top. This addition ensures Kurdish developers are properly recognized and included in regional statistics.

New preset addition:

* Added a `kurdistan` entry to the `PRESETS` map, including relevant cities such as "erbil", "hawler", "sulaymaniyah", "slemani", "duhok", "halabja", and "kirkuk".

Generated commit https://github.com/ravensborn/committers.top/commit/57c6a39ff9b168c4bb639b4fa4dfedca84da8f1f