### PR TITLE
Fix plain/csv ranking and add test

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -18,7 +18,7 @@ import (
 type Format func(results github.GithubSearchResults, writer io.Writer, options top.Options) error
 
 func PlainOutput(results github.GithubSearchResults, writer io.Writer, options top.Options) error {
-	users := GithubUserList(results.Users)
+	users := GithubUserList(results.Users).TopPrivate(options.Amount)
 	fmt.Fprintln(writer, "USERS\n--------")
 	for i, user := range users {
 		fmt.Fprintf(writer, "#%+v: %+v (%+v):%+v (%+v) %+v\n", i+1, user.Name, user.Login, user.ContributionCount, user.Company, strings.Join(user.Organizations, ","))
@@ -31,7 +31,7 @@ func PlainOutput(results github.GithubSearchResults, writer io.Writer, options t
 }
 
 func CsvOutput(results github.GithubSearchResults, writer io.Writer, options top.Options) error {
-	users := GithubUserList(results.Users)
+	users := GithubUserList(results.Users).TopPrivate(options.Amount)
 	w := csv.NewWriter(writer)
 	if err := w.Write([]string{"rank", "name", "login", "contributions", "company", "organizations"}); err != nil {
 		return err
@@ -195,7 +195,13 @@ func (slice TopCommitsUsers) Len() int {
 }
 
 func (slice TopCommitsUsers) Less(i, j int) bool {
-	return slice[i].CommitsCount > slice[j].CommitsCount
+	if slice[i].CommitsCount != slice[j].CommitsCount {
+		return slice[i].CommitsCount > slice[j].CommitsCount
+	}
+	if slice[i].FollowerCount != slice[j].FollowerCount {
+		return slice[i].FollowerCount > slice[j].FollowerCount
+	}
+	return strings.ToLower(slice[i].Login) < strings.ToLower(slice[j].Login)
 }
 
 func (slice TopCommitsUsers) Swap(i, j int) {
@@ -209,7 +215,13 @@ func (slice TopPublicUsers) Len() int {
 }
 
 func (slice TopPublicUsers) Less(i, j int) bool {
-	return slice[i].PublicContributionCount > slice[j].PublicContributionCount
+	if slice[i].PublicContributionCount != slice[j].PublicContributionCount {
+		return slice[i].PublicContributionCount > slice[j].PublicContributionCount
+	}
+	if slice[i].FollowerCount != slice[j].FollowerCount {
+		return slice[i].FollowerCount > slice[j].FollowerCount
+	}
+	return strings.ToLower(slice[i].Login) < strings.ToLower(slice[j].Login)
 }
 
 func (slice TopPublicUsers) Swap(i, j int) {
@@ -223,7 +235,13 @@ func (slice TopPrivateUsers) Len() int {
 }
 
 func (slice TopPrivateUsers) Less(i, j int) bool {
-	return slice[i].ContributionCount > slice[j].ContributionCount
+	if slice[i].ContributionCount != slice[j].ContributionCount {
+		return slice[i].ContributionCount > slice[j].ContributionCount
+	}
+	if slice[i].FollowerCount != slice[j].FollowerCount {
+		return slice[i].FollowerCount > slice[j].FollowerCount
+	}
+	return strings.ToLower(slice[i].Login) < strings.ToLower(slice[j].Login)
 }
 
 func (slice TopPrivateUsers) Swap(i, j int) {
@@ -242,7 +260,10 @@ func (slice Organizations) Len() int {
 }
 
 func (slice Organizations) Less(i, j int) bool {
-	return slice[i].MemberCount > slice[j].MemberCount
+	if slice[i].MemberCount != slice[j].MemberCount {
+		return slice[i].MemberCount > slice[j].MemberCount
+	}
+	return strings.ToLower(slice[i].Name) < strings.ToLower(slice[j].Name)
 }
 
 func (slice Organizations) Swap(i, j int) {

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -1,0 +1,44 @@
+package output
+
+import (
+	"bytes"
+	"encoding/csv"
+	"testing"
+
+	"most-active-github-users-counter/github"
+	"most-active-github-users-counter/top"
+)
+
+func TestCsvOutput_SortsByContributionsAndRespectsAmount(t *testing.T) {
+	results := github.GithubSearchResults{
+		Users: []github.User{
+			{Login: "a", ContributionCount: 10, FollowerCount: 999},
+			{Login: "b", ContributionCount: 20, FollowerCount: 1},
+			{Login: "c", ContributionCount: 20, FollowerCount: 5},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := CsvOutput(results, &buf, top.Options{Amount: 2}); err != nil {
+		t.Fatalf("CsvOutput error: %v", err)
+	}
+
+	r := csv.NewReader(bytes.NewReader(buf.Bytes()))
+	rows, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("failed to parse csv: %v", err)
+	}
+
+	// header + 2 rows (because Amount=2)
+	if got, want := len(rows), 3; got != want {
+		t.Fatalf("unexpected number of rows: got %d want %d", got, want)
+	}
+
+	if got, want := rows[1][2], "c"; got != want {
+		t.Fatalf("rank 1 login mismatch: got %q want %q", got, want)
+	}
+	if got, want := rows[2][2], "b"; got != want {
+		t.Fatalf("rank 2 login mismatch: got %q want %q", got, want)
+	}
+}
+


### PR DESCRIPTION
**Title**
Fix inaccurate ranks in plain/CSV output

**Description**
This PR fixes incorrect ranking when using `--output plain` or `--output csv`. Previously, these formats printed users in the GitHub search order (sorted by followers) and didn’t apply `--amount`, which could produce misleading ranks.

Changes:
- Sort and trim `plain`/`csv` outputs by contribution count and respect `--amount`.
- Add deterministic tie-breakers (followers, then login) to avoid rank jitter on ties.
- Add a regression test for CSV ordering + trimming.

Files:
- `output/output.go`
- `output/output_test.go`