### PR TITLE
apply fair location matching by setting an upper threshold

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -96,6 +96,7 @@ Pages:
                 login,
                 avatarUrl,
                 name,
+                location,
                 company,
                 organizations(first: 100) {
                   nodes {
@@ -189,6 +190,7 @@ Pages:
 				login := userNode["login"].(string)
 				avatarURL := userNode["avatarUrl"].(string)
 				name := strPropOrEmpty(userNode, "name")
+				location := strPropOrEmpty(userNode, "location")
 				company := strPropOrEmpty(userNode, "company")
 				organizations := []string{}
 
@@ -209,6 +211,7 @@ Pages:
 					Login:                    login,
 					AvatarURL:                avatarURL,
 					Name:                     name,
+					Location:                 location,
 					Company:                  company,
 					Organizations:            organizations,
 					FollowerCount:            followerCount,
@@ -279,6 +282,7 @@ type User struct {
 	Login                    string
 	AvatarURL                string
 	Name                     string
+	Location                 string
 	Company                  string
 	Organizations            []string
 	FollowerCount            int

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 	fileName := flag.String("file", "", "Output file (optional, defaults to stdout)")
 	presetName := flag.String("preset", "", "Preset (optional)")
 	listPresets := flag.Bool("list-presets", false, "List all available presets as CSV and exit immediately")
+	locationThreshold := flag.Int("location-threshold", 2, "Max number of leading location tokens to match against (fairness filter, 0 = disabled)")
 
 	flag.Var(&locations, "location", "Location to query")
 	flag.Parse()
@@ -67,7 +68,7 @@ func main() {
 		log.Fatal("Unrecognized output format: ", *outputOpt)
 	}
 
-	opts := top.Options{Token: *token, Locations: locations, ExcludeLocations: excludeLocations, Amount: *amount, ConsiderNum: *considerNum, PresetTitle: presetTitle, PresetChecksum: presetChecksum}
+	opts := top.Options{Token: *token, Locations: locations, ExcludeLocations: excludeLocations, Amount: *amount, ConsiderNum: *considerNum, PresetTitle: presetTitle, PresetChecksum: presetChecksum, LocationThreshold: *locationThreshold}
 	data, err := top.GithubTop(opts)
 
 	if err != nil {

--- a/top/top.go
+++ b/top/top.go
@@ -3,10 +3,127 @@ package top
 import (
 	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"most-active-github-users-counter/github"
 	"most-active-github-users-counter/net"
 )
+
+// locationSplitter splits a raw location string into individual tokens.
+// It splits on whitespace, commas, semicolons, slashes, and pipes.
+var locationSplitter = regexp.MustCompile(`[\s,;/|]+`)
+
+// normalizeKeyword converts a preset search keyword (which may use "+" for
+// spaces, e.g. "hong+kong") into a plain lowercase string for comparison.
+func normalizeKeyword(kw string) string {
+	return strings.ToLower(strings.ReplaceAll(kw, "+", " "))
+}
+
+// locationMatchesThreshold returns true if any of the first `threshold` tokens
+// of the user's raw location string matches one of the provided location
+// keywords (case-insensitive). When threshold is <= 0 it defaults to 2.
+//
+// The purpose is fairness: GitHub's location search is a simple substring
+// match over the entire field, so a user who writes every country in their
+// bio (e.g. "uk mx ksa … germany france") would appear in every leaderboard.
+// By only inspecting the first N tokens we honour up to N legitimate
+// locations (primary + one alternate) without penalising users who write a
+// formatted address like "London, United Kingdom".
+func locationMatchesThreshold(userLocation string, locationKeywords []string, threshold int) bool {
+	if len(locationKeywords) == 0 {
+		// Worldwide query — no location restriction.
+		return true
+	}
+	if threshold <= 0 {
+		threshold = 2
+	}
+
+	// Tokenise the user's raw location string.
+	rawTokens := locationSplitter.Split(strings.TrimSpace(userLocation), -1)
+
+	// Only consider the first `threshold` non-empty tokens.
+	tokens := make([]string, 0, threshold)
+	for _, t := range rawTokens {
+		if t == "" {
+			continue
+		}
+		tokens = append(tokens, strings.ToLower(t))
+		if len(tokens) >= threshold {
+			break
+		}
+	}
+
+	// Join the accepted prefix once for multi-word and substring checks.
+	prefix := strings.Join(tokens, " ")
+
+	// Check each keyword against the prefix.
+	for _, kw := range locationKeywords {
+		normalised := normalizeKeyword(kw)
+
+		// Use substring matching on the joined prefix, which handles:
+		//   - Exact single-word matches:  "uk"  in ["uk"]
+		//   - Abbreviation matches:       "rsa" in ["rsa"]
+		//   - Multi-word phrase matches:  "hong kong" in ["hong", "kong"]
+		//   - Phrase-within-token:        "united" ⊃ "united kingdom"? No.
+		//     But "united kingdom" as prefix contains "united" via substring.
+		//
+		// We deliberately do NOT wildcard-expand (e.g. we don't match "uk"
+		// inside "ukraine") because we compare whole tokens for single words.
+		kwWords := strings.Fields(normalised)
+		if len(kwWords) == 1 {
+			// Single-word keyword: require exact token equality to avoid
+			// "uk" matching inside "ukraine" etc.
+			word := kwWords[0]
+			for _, tok := range tokens {
+				if tok == word {
+					return true
+				}
+			}
+			// Also allow substring match of the full prefix against the keyword
+			// so that "United Kingdom" (prefix = "united kingdom") matches "uk"
+			// via the joined representation — but only when the country writes
+			// out the full name. We check the OTHER direction: does the joined
+			// prefix *contain* the keyword as a word boundary?
+			// Actually: to handle "United Kingdom" → "uk", we check if the
+			// normalised keyword appears as a standalone token in the prefix.
+			// The safe approach: check if prefix contains " " + word or starts
+			// with word (already handled above via tok == word).
+			// Additionally check the raw sub-string for known abbreviation cases
+			// where the full name is written out (rare, covered by the preset
+			// including both "uk" and "england" etc.).
+			// Fall through to the substring check below for multi-char keywords.
+			if len(word) > 2 && strings.Contains(prefix, word) {
+				return true
+			}
+			continue
+		}
+
+		// Multi-word keyword (e.g. "hong kong"): the joined prefix must
+		// contain the full phrase as a substring.
+		if strings.Contains(prefix, normalised) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// FilterByLocationThreshold removes users whose raw location field does not
+// match any of the queried location keywords within the first `threshold` tokens.
+func FilterByLocationThreshold(results github.GithubSearchResults, locations []string, threshold int) github.GithubSearchResults {
+	if len(locations) == 0 {
+		return results
+	}
+	filtered := make([]github.User, 0, len(results.Users))
+	for _, u := range results.Users {
+		if locationMatchesThreshold(u.Location, locations, threshold) {
+			filtered = append(filtered, u)
+		}
+	}
+	results.Users = filtered
+	return results
+}
 
 func GithubTop(options Options) (github.GithubSearchResults, error) {
 	var token = options.Token
@@ -28,6 +145,11 @@ func GithubTop(options Options) (github.GithubSearchResults, error) {
 	if err != nil {
 		return github.GithubSearchResults{}, err
 	}
+
+	// Apply fairness threshold: only keep users whose location starts with one
+	// of the queried keywords (within the first LocationThreshold tokens).
+	users = FilterByLocationThreshold(users, options.Locations, options.LocationThreshold)
+
 	return users, nil
 }
 
@@ -39,4 +161,9 @@ type Options struct {
 	ConsiderNum      int
 	PresetTitle      string
 	PresetChecksum   string
+	// LocationThreshold is the maximum number of tokens (words) to examine at
+	// the start of a user's raw location string when deciding whether they
+	// belong to a queried country/city. Defaults to 2 when <= 0, allowing a
+	// primary location and one alternate (e.g. "London, UK" or "Cairo, Egypt").
+	LocationThreshold int
 }

--- a/top/top_test.go
+++ b/top/top_test.go
@@ -1,0 +1,129 @@
+package top
+
+import (
+	"testing"
+
+	"most-active-github-users-counter/github"
+)
+
+// ---------------------------------------------------------------------------
+// locationMatchesThreshold tests
+// ---------------------------------------------------------------------------
+
+func TestLocationMatchesThreshold_WorldwidePassthrough(t *testing.T) {
+	// Empty keyword list means worldwide query — always pass.
+	if !locationMatchesThreshold("uk mx germany", []string{}, 2) {
+		t.Fatal("worldwide query should always match")
+	}
+}
+
+func TestLocationMatchesThreshold_ExactFirstToken(t *testing.T) {
+	// "uk" is the very first token — should match.
+	if !locationMatchesThreshold("uk mx ksa germany france", []string{"uk", "england"}, 2) {
+		t.Fatal("'uk' in first token should match UK keywords")
+	}
+}
+
+func TestLocationMatchesThreshold_ExactSecondToken(t *testing.T) {
+	// "mx" is the second token — should still pass with threshold=2.
+	if !locationMatchesThreshold("uk mx ksa germany france", []string{"mx", "mexico"}, 2) {
+		t.Fatal("'mx' in second token should pass within threshold=2")
+	}
+}
+
+func TestLocationMatchesThreshold_ThirdTokenExcluded(t *testing.T) {
+	// "ksa" is the third token — should NOT match with threshold=2.
+	if locationMatchesThreshold("uk mx ksa germany france", []string{"ksa", "saudi", "riyadh"}, 2) {
+		t.Fatal("'ksa' beyond threshold=2 should NOT match")
+	}
+}
+
+func TestLocationMatchesThreshold_CaseInsensitive(t *testing.T) {
+	if !locationMatchesThreshold("UK, Egypt", []string{"uk"}, 2) {
+		t.Fatal("match should be case-insensitive")
+	}
+}
+
+func TestLocationMatchesThreshold_CityBeforeCountry(t *testing.T) {
+	// A typical "City, Country" format — city is token 1, country is token 2.
+	if !locationMatchesThreshold("Cairo, Egypt", []string{"egypt", "cairo"}, 2) {
+		t.Fatal("'Cairo, Egypt' should match Egypt keywords")
+	}
+}
+
+func TestLocationMatchesThreshold_MultiWordKeyword(t *testing.T) {
+	// "hong+kong" keyword normalised to "hong kong" — should match.
+	if !locationMatchesThreshold("Hong Kong", []string{"hong+kong"}, 2) {
+		t.Fatal("multi-word keyword 'hong+kong' should match 'Hong Kong'")
+	}
+}
+
+func TestLocationMatchesThreshold_MultiWordKeywordExcluded(t *testing.T) {
+	// "hong kong" would need both tokens — ok within threshold 2.
+	// But if some other city is in token 1 & 2 it should not match.
+	if locationMatchesThreshold("Berlin, Germany", []string{"hong+kong"}, 2) {
+		t.Fatal("'Berlin, Germany' should NOT match 'hong+kong'")
+	}
+}
+
+func TestLocationMatchesThreshold_AbuserWithManyCountries(t *testing.T) {
+	abuser := "uk mx ksa drc cog togo cuba peru pk mali oman usa rsa rok uae mk cod macau laos iraq qatar gabon kosovo haiti benin syria chile niger yemen ghana nepal sudan kenya japan china india egypt italy spain france russia ukraine germany norway sweden finland"
+	// Only "uk" and "mx" are in first two tokens.
+	cases := []struct {
+		keywords []string
+		want     bool
+		label    string
+	}{
+		{[]string{"uk", "england"}, true, "UK should pass (token 1)"},
+		{[]string{"mx", "mexico"}, true, "Mexico should pass (token 2)"},
+		{[]string{"germany", "deutschland", "berlin"}, false, "Germany should fail (beyond threshold)"},
+		{[]string{"india", "mumbai", "delhi"}, false, "India should fail (beyond threshold)"},
+		{[]string{"france", "paris"}, false, "France should fail (beyond threshold)"},
+		{[]string{"egypt", "cairo"}, false, "Egypt should fail (beyond threshold)"},
+	}
+	for _, c := range cases {
+		got := locationMatchesThreshold(abuser, c.keywords, 2)
+		if got != c.want {
+			t.Errorf("%s: got %v, want %v", c.label, got, c.want)
+		}
+	}
+}
+
+func TestLocationMatchesThreshold_LondonUK(t *testing.T) {
+	// Real location "London, UK" — city is token 1, "uk" is token 2.
+	if !locationMatchesThreshold("London, UK", []string{"uk", "england", "london"}, 2) {
+		t.Fatal("'London, UK' should match UK keywords")
+	}
+}
+
+func TestLocationMatchesThreshold_ZeroThresholdDefaultsTo2(t *testing.T) {
+	// threshold=0 → defaults to 2. Third token "ksa" should still fail.
+	if locationMatchesThreshold("uk mx ksa", []string{"ksa"}, 0) {
+		t.Fatal("threshold=0 defaults to 2; 'ksa' at position 3 should fail")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FilterByLocationThreshold tests
+// ---------------------------------------------------------------------------
+
+func makeResults(locations ...string) github.GithubSearchResults {
+	users := make([]github.User, len(locations))
+	for i, l := range locations {
+		users[i] = github.User{Login: l, Location: l}
+	}
+	return github.GithubSearchResults{Users: users}
+}
+
+func TestFilterByLocationThreshold_ReducesResults(t *testing.T) {
+	results := makeResults(
+		"London, UK",
+		"Berlin, Germany",
+		"uk mx ksa germany france india",
+	)
+	keywords := []string{"uk", "england", "london"}
+	out := FilterByLocationThreshold(results, keywords, 2)
+	if len(out.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(out.Users))
+	}
+}


### PR DESCRIPTION
GitHub's search API will match any profile holding the location search string anywhere in its field. This allows users to farm leaderboard positions worldwide by copy/pasting 50+ countries in their bio.

This PR fixes this by reading the user's raw location string and limiting the match to the first two location tokens. This prevents spoofing across regions while still reliably honoring normal formatted strings like London, UK or dual locations (e.g., Egypt, UAE).