### PR TITLE
ignore users with unrealistic commit trends

### DIFF
--- a/top/top.go
+++ b/top/top.go
@@ -8,6 +8,51 @@ import (
 	"most-active-github-users-counter/net"
 )
 
+// IsLikelyFakeCommitter returns true when a user's GitHub activity pattern
+// strongly suggests that their commit count is inflated by automation, scripts,
+// or bulk-push workflows rather than genuine software development.
+//
+// The thresholds are intentionally conservative to avoid false-positives on
+// extremely productive real developers:
+//
+//  1. >50 000 commits in a year — no human being ships code at 137 commits/day.
+//  2. >5 000 commits with fewer than 10 pull requests — automated pushers
+//     almost never open PRs because they're not collaborating with anyone.
+//  3. >3 000 commits with <3 followers — bot/throwaway accounts that nobody
+//     follows despite allegedly massive output.
+func IsLikelyFakeCommitter(user github.User) bool {
+	// Rule 1: physically impossible yearly commit rate.
+	if user.CommitsCount > 50000 {
+		return true
+	}
+
+	// Rule 2: high volume, nearly zero pull-request activity.
+	if user.CommitsCount > 5000 && user.PullRequestsCount < 10 {
+		return true
+	}
+
+	// Rule 3: high volume, essentially no followers.
+	if user.CommitsCount > 3000 && user.FollowerCount < 3 {
+		return true
+	}
+
+	return false
+}
+
+// FilterFakeCommitters removes users whose commit patterns indicate
+// automated or bulk-generated activity.
+func FilterFakeCommitters(results github.GithubSearchResults) github.GithubSearchResults {
+	filtered := make([]github.User, 0, len(results.Users))
+	for _, u := range results.Users {
+		if IsLikelyFakeCommitter(u) {
+			continue
+		}
+		filtered = append(filtered, u)
+	}
+	results.Users = filtered
+	return results
+}
+
 func GithubTop(options Options) (github.GithubSearchResults, error) {
 	var token = options.Token
 	if token == "" {
@@ -28,6 +73,10 @@ func GithubTop(options Options) (github.GithubSearchResults, error) {
 	if err != nil {
 		return github.GithubSearchResults{}, err
 	}
+
+	// Filter out developers manipulating the leaderboards with bot commits.
+	users = FilterFakeCommitters(users)
+
 	return users, nil
 }
 
@@ -40,3 +89,4 @@ type Options struct {
 	PresetTitle      string
 	PresetChecksum   string
 }
+

--- a/top/top_test.go
+++ b/top/top_test.go
@@ -1,0 +1,48 @@
+package top
+
+import (
+	"testing"
+
+	"most-active-github-users-counter/github"
+)
+
+// ---------------------------------------------------------------------------
+// IsLikelyFakeCommitter tests
+// ---------------------------------------------------------------------------
+
+func TestIsLikelyFakeCommitter_Normal(t *testing.T) {
+	u := github.User{CommitsCount: 500, PullRequestsCount: 50, FollowerCount: 200}
+	if IsLikelyFakeCommitter(u) {
+		t.Fatal("normal developer should not be flagged")
+	}
+}
+
+func TestIsLikelyFakeCommitter_TooManyCommits(t *testing.T) {
+	u := github.User{CommitsCount: 80000, PullRequestsCount: 5, FollowerCount: 2}
+	if !IsLikelyFakeCommitter(u) {
+		t.Fatal("80k commits/year should be flagged as fake")
+	}
+}
+
+func TestIsLikelyFakeCommitter_HighCommitsNoPRs(t *testing.T) {
+	// 8000 commits, 0 PRs — automated push workflow.
+	u := github.User{CommitsCount: 8000, PullRequestsCount: 0, FollowerCount: 50}
+	if !IsLikelyFakeCommitter(u) {
+		t.Fatal("high commits with zero PRs should be flagged")
+	}
+}
+
+func TestIsLikelyFakeCommitter_HighCommitsNoFollowers(t *testing.T) {
+	u := github.User{CommitsCount: 5000, PullRequestsCount: 3, FollowerCount: 1}
+	if !IsLikelyFakeCommitter(u) {
+		t.Fatal("high commits with near-zero followers should be flagged")
+	}
+}
+
+func TestIsLikelyFakeCommitter_ActiveDeveloperNotFlagged(t *testing.T) {
+	// Very active real developer: many commits, reasonable PRs, followers.
+	u := github.User{CommitsCount: 3000, PullRequestsCount: 120, FollowerCount: 500}
+	if IsLikelyFakeCommitter(u) {
+		t.Fatal("active real developer should not be flagged")
+	}
+}


### PR DESCRIPTION
Some accounts rely on scripts or fake workflows to auto-generate tens of thousands of unused commits exclusively to top the charts.

This PR adds heuristic checks to catch physically impossible dev patterns. It kicks out automated committers by ignoring accounts that generate 50k+ commits a year, or push thousands of commits but have essentially zero active pull requests or followers.

