### PR TITLE
feat: introduce user blacklist via embedded text file

### DIFF
--- a/top/blacklist.go
+++ b/top/blacklist.go
@@ -1,0 +1,34 @@
+package top
+
+import (
+	_ "embed"
+	"strings"
+	"sync"
+)
+
+//go:embed blacklist.txt
+var blacklistData string
+
+var (
+	blacklistedUsers map[string]struct{}
+	blacklistOnce    sync.Once
+)
+
+func initBlacklist() {
+	blacklistedUsers = make(map[string]struct{})
+	lines := strings.Split(blacklistData, "\n")
+	for _, line := range lines {
+		user := strings.TrimSpace(line)
+		if user != "" {
+			blacklistedUsers[strings.ToLower(user)] = struct{}{}
+		}
+	}
+}
+
+// IsBlacklisted reports whether the given GitHub login is on the blacklist.
+// The check is case-insensitive so casing variations can't bypass it.
+func IsBlacklisted(login string) bool {
+	blacklistOnce.Do(initBlacklist)
+	_, ok := blacklistedUsers[strings.ToLower(login)]
+	return ok
+}

--- a/top/blacklist.txt
+++ b/top/blacklist.txt
@@ -1,0 +1,6 @@
+themiralay
+komutan234
+buraksocial
+Zer0-Bug
+wajahat-ali-mir-dev
+haroonrashidzadran

--- a/top/top.go
+++ b/top/top.go
@@ -8,6 +8,19 @@ import (
 	"most-active-github-users-counter/net"
 )
 
+// FilterBlacklistedUsers removes any users who are marked as known graph abusers.
+func FilterBlacklistedUsers(results github.GithubSearchResults) github.GithubSearchResults {
+	filtered := make([]github.User, 0, len(results.Users))
+	for _, u := range results.Users {
+		if IsBlacklisted(u.Login) {
+			continue
+		}
+		filtered = append(filtered, u)
+	}
+	results.Users = filtered
+	return results
+}
+
 func GithubTop(options Options) (github.GithubSearchResults, error) {
 	var token = options.Token
 	if token == "" {
@@ -28,6 +41,10 @@ func GithubTop(options Options) (github.GithubSearchResults, error) {
 	if err != nil {
 		return github.GithubSearchResults{}, err
 	}
+
+	// Filter out explicitly blacklisted abusive accounts.
+	users = FilterBlacklistedUsers(users)
+
 	return users, nil
 }
 
@@ -40,3 +57,4 @@ type Options struct {
 	PresetTitle      string
 	PresetChecksum   string
 }
+

--- a/top/top_test.go
+++ b/top/top_test.go
@@ -1,0 +1,32 @@
+package top
+
+import (
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Blacklist tests
+// ---------------------------------------------------------------------------
+
+func TestIsBlacklisted_KnownAbuser(t *testing.T) {
+	for _, name := range []string{
+		"themiralay", "komutan234", "buraksocial",
+		"Zer0-Bug", "wajahat-ali-mir-dev", "haroonrashidzadran",
+	} {
+		if !IsBlacklisted(name) {
+			t.Errorf("'%s' should be blacklisted", name)
+		}
+	}
+}
+
+func TestIsBlacklisted_NormalUser(t *testing.T) {
+	if IsBlacklisted("torvalds") {
+		t.Fatal("torvalds should not be blacklisted")
+	}
+}
+
+func TestIsBlacklisted_CaseInsensitive(t *testing.T) {
+	if !IsBlacklisted("THEMIRALAY") {
+		t.Fatal("blacklist check should be case-insensitive")
+	}
+}


### PR DESCRIPTION
This feature prevents well-known abusers from appearing in the leaderboard. The blacklist is easily maintained in a plaintext file.