### PR TITLE
Expand Austria preset with 14 missing cities

### DIFF
--- a/presets.go
+++ b/presets.go
@@ -24,7 +24,7 @@ var PRESETS = map[string]QueryPreset{
 	},
 	"austria": QueryPreset{
 		title:   "Austria",
-		include: []string{"austria", "österreich", "vienna", "wien", "linz", "salzburg", "graz", "innsbruck", "klagenfurt", "wels", "dornbirn"},
+		include: []string{"austria", "österreich", "vienna", "wien", "linz", "salzburg", "graz", "innsbruck", "klagenfurt", "wels", "dornbirn", "steyr", "villach", "wiener+neustadt", "st.+pölten", "st.+poelten", "bregenz", "krems", "feldkirch", "leoben", "kapfenberg", "mödling", "moedling", "klosterneuburg", "leonding", "traun", "amstetten", "wolfsberg", "schwechat", "enns", "baden+bei+wien"},
 	},
 	"armenia": QueryPreset{
 		title:   "Armenia",


### PR DESCRIPTION
## Summary

The current Austria preset covers the main cities but misses a significant number of smaller cities and towns where Austrian GitHub users are located.

This PR adds the following missing locations:

- **Steyr** (3rd largest city in Upper Austria)
- **Villach** (2nd largest city in Carinthia)
- **Wiener Neustadt** (major city in Lower Austria)
- **St. Pölten** (capital of Lower Austria) — with umlaut-free variant `st. poelten`
- **Bregenz** (capital of Vorarlberg)
- **Krems** (major Danube city, Lower Austria)
- **Feldkirch** (Vorarlberg)
- **Leoben** (Styria, major industrial/university city)
- **Kapfenberg** (Styria)
- **Mödling** (Lower Austria, Vienna suburb belt) — with umlaut-free variant `moedling`
- **Klosterneuburg** (Lower Austria)
- **Leonding** (Upper Austria, Linz suburb)
- **Traun** (Upper Austria)
- **Amstetten** (Lower Austria)
- **Wolfsberg** (Carinthia)
- **Schwechat** (Lower Austria, Vienna Airport area)
- **Enns** (oldest city in Austria, Upper Austria)
- **Baden bei Wien** (Lower Austria spa town)

Also adds ASCII-only variants (`st.+poelten`, `moedling`) for users whose GitHub profiles use non-umlaut location strings.

## Test plan

- [ ] Verified all added cities are within Austrian borders
- [ ] Umlaut variants match common ASCII transliterations used in GitHub profiles
- [ ] Format matches existing Austria preset entries