### PR TITLE
refactor: remove unused pull request contribution count

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -110,7 +110,6 @@ Pages:
                     totalContributions
                   },
                   totalCommitContributions,
-                  totalPullRequestContributions,
                   restrictedContributionsCount
                 }
               }
@@ -203,7 +202,6 @@ Pages:
 				contributionCount := int(contributionsCollection["contributionCalendar"].(map[string]interface{})["totalContributions"].(float64))
 				privateContributionCount := int(contributionsCollection["restrictedContributionsCount"].(float64))
 				commitsCount := int(contributionsCollection["totalCommitContributions"].(float64))
-				pullRequestsCount := int(contributionsCollection["totalPullRequestContributions"].(float64))
 
 				user := User{
 					Login:                    login,
@@ -215,8 +213,7 @@ Pages:
 					ContributionCount:        contributionCount,
 					PublicContributionCount:  (contributionCount - privateContributionCount),
 					PrivateContributionCount: privateContributionCount,
-					CommitsCount:             commitsCount,
-					PullRequestsCount:        pullRequestsCount}
+					CommitsCount:             commitsCount}
 
 				if !userLogins[login] {
 					userLogins[login] = true
@@ -286,7 +283,6 @@ type User struct {
 	PublicContributionCount  int
 	PrivateContributionCount int
 	CommitsCount             int
-	PullRequestsCount        int
 }
 
 type UserSearchQuery struct {


### PR DESCRIPTION
Remove the unused pull request contribution count from the GitHub GraphQL query and related data structures.

The pull request contribution count was being fetched and parsed, but it was not used anywhere in the final output. Removing it simplifies the query and data model without changing the generated results.