### PR TITLE
refactor: reduce GraphQL search page size from 5 to 4

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -68,7 +68,7 @@ func (client HTTPGithubClient) SearchUsers(query UserSearchQuery) (GithubSearchR
 	totalCount := 0
 	minFollowerCount := -1
 	maxPerQuery := 1000
-	perPage := 5
+	perPage := 4
 	totalUsersCount := 0
 
 	retryCount := 0


### PR DESCRIPTION
Reduce expanded users per GraphQL request from 5 to 4 to lower payload and fan-out (~20%). This increases total requests, but the goal is to reduce `RESOURCE_LIMITS_EXCEEDED` risk, not wall-clock runtime.